### PR TITLE
Do not compute stats on non-saved products

### DIFF
--- a/statsproduct.php
+++ b/statsproduct.php
@@ -109,7 +109,7 @@ class StatsProduct extends ModuleGraph
 				'.Shop::addSqlAssociation('product', 'p').'
 				'.(Tools::getValue('id_category') ? 'LEFT JOIN `'._DB_PREFIX_.'category_product` cp ON p.`id_product` = cp.`id_product`' : '').'
 				WHERE pl.`id_lang` = '.(int)$id_lang.'
-					'.(Tools::getValue('id_category') ? 'AND cp.id_category = '.(int)Tools::getValue('id_category') : '').'
+					'.(Tools::getValue('id_category') ? 'AND cp.id_category = '.(int)Tools::getValue('id_category') : '').' AND p.state = '. Product::STATE_SAVED . '
 				ORDER BY pl.`name`';
 
 		return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | dev
| Description?  | The stats should not be computed on non-saved products
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | http://forge.prestashop.com/browse/BOOM-1168
| How to test?  |  <ul><li>Create & save 1 product</li><li>Create 1 product but do not save it</li><li>Go to Statistics > Product Details</li><li>You should not see the product you didn't save</li><li>It should not appear in the CSV export either</li></ul>