### PR TITLE
[BO] stats > product details > (select a product). Graph wrong

### DIFF
--- a/statsproduct.php
+++ b/statsproduct.php
@@ -384,9 +384,8 @@ class statsproduct extends ModuleGraph
         $date_between = $this->getDate();
         switch ($this->option) {
             case 1:
-                $this->_titles['main'][0] = $this->trans('Popularity', array(), 'Modules.Statsproduct.Admin');
-                $this->_titles['main'][1] = $this->trans('Sales', array(), 'Admin.Global');
-                $this->_titles['main'][2] = $this->trans('Visits (x100)', array(), 'Modules.Statsproduct.Admin');
+                $this->_titles['main'][0] = $this->trans('Sales', array(), 'Admin.Global');
+                $this->_titles['main'][1] = $this->trans('Visits (x100)', array(), 'Modules.Statsproduct.Admin');
                 $this->query[0] = 'SELECT o.`date_add`, SUM(od.`product_quantity`) AS total
 						FROM `'._DB_PREFIX_.'order_detail` od
 						LEFT JOIN `'._DB_PREFIX_.'orders` o ON o.`id_order` = od.`id_order`


### PR DESCRIPTION
stats > product details > (select a product). Graph shows "popular" which is really sales, and "sales" which is actually visits x 100, labeled wrong.

As you can see higher in code there are only 2 layers shown, so not even sure why popular was a thought... since it doesn't have a query even.