### PR TITLE
Fix graphic stats stop working since PHP 7.1 version

### DIFF
--- a/statsproduct.php
+++ b/statsproduct.php
@@ -31,7 +31,7 @@ if (!defined('_PS_VERSION_')) {
 class statsproduct extends ModuleGraph
 {
     private $html = '';
-    private $query = '';
+    private $query = [];
     private $option = 0;
     private $id_product = 0;
 


### PR DESCRIPTION
Hi,

Since PHP 7.1 version, the module output this PHP warning and the graphic stop working:
```
Invalid argument supplied for foreach()
``` 

It's because the `$query` variable is declare as string instead array.
Since version 7.1, PHP stop to converting an empty string to array https://www.php.net/manual/en/migration71.incompatible.php#migration71.incompatible.empty-string-modifcation-by-character

We encountering the same bug on the **statsvisits** module.
Here one open issue: https://github.com/PrestaShop/statsvisits/pull/13

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Description above.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes {paste the issue here}.
| How to test?  | Test statsproduct back office page with PHP 7.1 or above. The graph shows now values. 
