### PR TITLE
Missing deleteds attributes names in product stats module 

### DIFF
--- a/statsproduct.php
+++ b/statsproduct.php
@@ -442,34 +442,12 @@ class statsproduct extends ModuleGraph
         } elseif ($this->option != 3) {
             $this->setDateGraph($layers, true);
         } else {
-            $product = new Product($this->id_product, false, (int)$this->getLang());
-
             $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($this->query);
             foreach ($result as $row) {
                 $this->_values[] = $row['total'];
-                $this->_legend[] = $this->removeProductNameInCombinationName($product->name, $row['product_name']);
+                $this->_legend[] = $row['product_name'];
             }
         }
-    }
-
-    /**
-     * @param string $productName
-     * @param string $combinationName
-     *
-     * @return string
-     */
-    protected function removeProductNameInCombinationName(string $productName, string $combinationName): string
-    {
-        $combinationFullNameSepatators = ['-', ':'];
-        $combinationName = str_replace($productName, '', $combinationName);
-        $combinationName = trim($combinationName);
-
-        if(in_array($combinationName[0], $combinationFullNameSepatators)){
-            $combinationName = ltrim($combinationName, $combinationName[0]);
-        }
-
-        return trim($combinationName);
-
     }
 
     protected function setAllTimeValues($layers)

--- a/statsproduct.php
+++ b/statsproduct.php
@@ -458,7 +458,8 @@ class statsproduct extends ModuleGraph
      *
      * @return string
      */
-    protected function removeProductNameInCombinationName(string $productName, string $combinationName): string{
+    protected function removeProductNameInCombinationName(string $productName, string $combinationName): string
+    {
         $combinationFullNameSepatators = ['-', ':'];
         $combinationName = str_replace($productName, '', $combinationName);
         $combinationName = trim($combinationName);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Improve `statsproduct::getData`
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/25049
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/25049
| Possible impacts? | Product full name is displayed (product + attributes) instead only attributes

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
