### PR TITLE
Bump to 2.1.0 and change prestashop compatibility

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>statsproduct</name>
 	<displayName><![CDATA[Product details]]></displayName>
-	<version><![CDATA[2.0.3]]></version>
+	<version><![CDATA[2.1.0]]></version>
 	<description><![CDATA[Adds detailed statistics for each product to the Stats dashboard.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[analytics_stats]]></tab>

--- a/statsproduct.php
+++ b/statsproduct.php
@@ -39,7 +39,7 @@ class statsproduct extends ModuleGraph
     {
         $this->name = 'statsproduct';
         $this->tab = 'analytics_stats';
-        $this->version = '2.0.3';
+        $this->version = '2.1.0';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -47,7 +47,7 @@ class statsproduct extends ModuleGraph
 
         $this->displayName = $this->trans('Product details', array(), 'Modules.Statsproduct.Admin');
         $this->description = $this->trans('Enrich your stats, add detailed statistics for each product of your catalog.', array(), 'Modules.Statsproduct.Admin');
-        $this->ps_versions_compliancy = array('min' => '1.7.1.0', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '1.7.6.0', 'max' => _PS_VERSION_);
     }
 
     public function install()


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | We have to update compatibility because of Tools::displayPrice which will be removed in the next PrestaShop version

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
